### PR TITLE
Updated bootstrap2 errors template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ What Works So Far?
 ==================
 
 * The Bootstrap 3 Horizontal Form layout http://getbootstrap.com/css/#forms-horizontal
+* The Bootstrap 3 Inline Form layout http://getbootstrap.com/css/#forms-inline
+
+Installation
+============
+
+There are multiple ways:
+
+1. Clone this git repo into your base Django project folder
+2. Install with pip ``git+https://github.com/BrnoPCmaniak/django-floppyforms-bootstrap3@master``
 
 How To Use
 ==========
 
-* Clone the git repo into the base directory of your Django Project, and add it to settings.py just like any other app.
 * Make sure this app is included in setings.py apps *before* floppy forms, as otherwise the template overriding doesn't seem to work properly.
 * Use floppyforms as normal.
 * Start with the example code below for how to use it.

--- a/floppyforms_bootstrap3/templates/floppyforms/attrs_without_form-control.html
+++ b/floppyforms_bootstrap3/templates/floppyforms/attrs_without_form-control.html
@@ -1,0 +1,5 @@
+{% if "class" in attrs.keys %}
+{% for name, value in attrs.items %} {{ name }}{% if name == "class" %}=" {{ value }}"{% elif value != True %}="{{ value }}"{% endif %}{% endfor %}
+{% else %}
+{% for name, value in attrs.items %} {{ name }}{% if value != True %}="{{ value }}"{% endif %}{% endfor %}
+{% endif %}

--- a/floppyforms_bootstrap3/templates/floppyforms/checkbox.html
+++ b/floppyforms_bootstrap3/templates/floppyforms/checkbox.html
@@ -1,0 +1,1 @@
+{% block content %}<input type="{{ type }}" name="{{ name }}"{% if value %} value="{{ value }}"{% endif %}{% if required %} required{% endif %}{% include "floppyforms/attrs_without_form-control.html" %}>{% endblock %}

--- a/floppyforms_bootstrap3/templates/floppyforms/errors.html
+++ b/floppyforms_bootstrap3/templates/floppyforms/errors.html
@@ -1,1 +1,1 @@
-{% if errors %}<span class="help-inline">{% for error in errors %}{{ error }}{% if not forloop.last %}<br />{% endif %}{% endfor %}</span>{% endif %}
+{% if errors %}<span class="help-block">{% for error in errors %}{{ error }}{% if not forloop.last %}<br />{% endif %}{% endfor %}</span>{% endif %}

--- a/floppyforms_bootstrap3/templates/floppyforms/rows/bootstrap3-inline.html
+++ b/floppyforms_bootstrap3/templates/floppyforms/rows/bootstrap3-inline.html
@@ -7,5 +7,4 @@
         {% block hidden_fields %}{% for field in hidden_fields %}{{ field.as_hidden }}{% endfor %}{% endblock %}
     {% endblock %}
     {% endwith %}
-</div><!--- .form-group{% if field.errors %}.error{% endif %} -->
-{% endfor %}{% endblock %}
+</div><!--- .form-group{% if field.errors %}.error{% endif %} -->{% endfor %}{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(*paths):
 
 setup(
     name='django-floppyforms-bootstrap3',
-    version='0.0.0',
+    version='0.0.1',
     packages=['floppyforms_bootstrap3',],
     description='A Plugin for Django Floppy Forms that provides Bootstrap 3 based form templates.',
     long_description=(read('README.md')),


### PR DESCRIPTION
Updated errors.html to use bootstrap3.

http://getbootstrap.com/migration/ - .help-inline -> .help-block